### PR TITLE
update to net9

### DIFF
--- a/Mod.RML/ResoniteMP3.cs
+++ b/Mod.RML/ResoniteMP3.cs
@@ -68,7 +68,7 @@ namespace resoniteMPThree
                 }
             }
 
-            public static string Mp3ToWav(string mp3File)
+            public static string Mp3ToOGG(string mp3File)
             {
                 string fileName = Path.GetTempPath() + "ResoniteMP3" + Path.DirectorySeparatorChar + Guid.NewGuid().ToString() + Path.DirectorySeparatorChar;
                 Msg("Creating temp folder: " + fileName);
@@ -105,7 +105,7 @@ namespace resoniteMPThree
                     if (Path.GetExtension(file) == ".mp3")
                     {
                         Msg("Discovered mp3 file in import");
-                        string newPath = Mp3ToWav(file);
+                        string newPath = Mp3ToOGG(file);
                         Msg("Creating temp folder and file: " + newPath);
                         files2.Add(newPath);
                     }

--- a/Mod.RML/ResoniteMP3.cs
+++ b/Mod.RML/ResoniteMP3.cs
@@ -2,7 +2,7 @@
 using Elements.Core;
 using FrooxEngine;
 using HarmonyLib;
-using NAudio.Wave;
+//using NAudio.Wave;
 using ResoniteModLoader;
 using System.Collections.Generic;
 using System.IO;
@@ -33,7 +33,7 @@ namespace resoniteMPThree
             Msg("ResoniteMP3 loaded.");
         }
 
-        private void clearTempFiles()
+        private static void clearTempFiles()
         {
             string tempDirectory = Path.GetTempPath() + "ResoniteMP3" + Path.DirectorySeparatorChar;
             if (Directory.Exists(tempDirectory))
@@ -50,7 +50,7 @@ namespace resoniteMPThree
             }
         }
 
-        public class PatchMethods
+        private static class PatchMethods
         {
 
             public static void FixExtensionMapping(ref AssetClass __result, string ext)
@@ -81,11 +81,11 @@ namespace resoniteMPThree
                     return mp3File;
                 }
                 
-                using (var reader = new Mp3FileReader(mp3File))
+               /* using (var reader = new Mp3FileReader(mp3File))
                 {
                     WaveFileWriter.CreateWaveFile(fileName, reader);
-                }
-
+                }*/
+            
                 return fileName;
             }
 

--- a/Mod.RML/ResoniteMP3.cs
+++ b/Mod.RML/ResoniteMP3.cs
@@ -2,11 +2,11 @@
 using Elements.Core;
 using FrooxEngine;
 using HarmonyLib;
-//using NAudio.Wave;
 using ResoniteModLoader;
 using System.Collections.Generic;
 using System.IO;
 using System;
+using FFMpegCore;
 
 
 namespace resoniteMPThree
@@ -71,7 +71,7 @@ namespace resoniteMPThree
                 string fileName = Path.GetTempPath() + "ResoniteMP3" + Path.DirectorySeparatorChar + Guid.NewGuid().ToString() + Path.DirectorySeparatorChar;
                 Msg("Creating temp folder: " + fileName);
                 Directory.CreateDirectory(fileName);
-                fileName += Path.GetFileNameWithoutExtension(mp3File) + ".wav";
+                fileName += Path.GetFileNameWithoutExtension(mp3File) + ".ogg";
                 Msg("Creating temp file: " + fileName);
                 if (File.Exists(fileName))
                 {
@@ -80,12 +80,12 @@ namespace resoniteMPThree
                     Error("Exiting ResoniteMP3 patch function...");
                     return mp3File;
                 }
-                
-               /* using (var reader = new Mp3FileReader(mp3File))
-                {
-                    WaveFileWriter.CreateWaveFile(fileName, reader);
-                }*/
-            
+
+                FFMpegArguments
+                    .FromFileInput(mp3File)
+                    .OutputToFile(fileName)
+                    .ProcessSynchronously();
+
                 return fileName;
             }
 
@@ -95,9 +95,9 @@ namespace resoniteMPThree
                 {
                     return true;
                 }
-                
+
                 List<string> files2 = new List<string>();
-                
+
                 foreach (string file in files)
                 {
                     if (Path.GetExtension(file) == ".mp3")

--- a/Mod.RML/ResoniteMP3.cs
+++ b/Mod.RML/ResoniteMP3.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.IO;
 using System;
 using FFMpegCore;
+using Instances;
+using FFMpegCore.Enums;
 
 
 namespace resoniteMPThree
@@ -83,7 +85,7 @@ namespace resoniteMPThree
 
                 FFMpegArguments
                     .FromFileInput(mp3File)
-                    .OutputToFile(fileName)
+                    .OutputToFile(fileName, true, options => options.WithArgument(new FFMpegCore.Arguments.CustomArgument(@"-vn")))
                     .ProcessSynchronously();
 
                 return fileName;

--- a/Mod.RML/ResoniteMP3.cs
+++ b/Mod.RML/ResoniteMP3.cs
@@ -6,13 +6,8 @@ using NAudio.Wave;
 using ResoniteModLoader;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using static FrooxEngine.CubemapCreator;
-using static FrooxEngine.Projection360Material;
-using System.Runtime.CompilerServices;
 using System;
-using System.Runtime.Remoting.Messaging;
+
 
 namespace resoniteMPThree
 {
@@ -20,7 +15,7 @@ namespace resoniteMPThree
     {
         public override string Name => "ResoniteMP3";
         public override string Author => "__Choco__";
-        public override string Version => "2.1.0"; //Version of the mod, should match the AssemblyVersion
+        public override string Version => "3.0.0"; //Version of the mod, should match the AssemblyVersion
         public override string Link => "https://github.com/AwesomeTornado/ResoniteMP3";
 
         public override void OnEngineInit()

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="Installed MonkeyLoader Mods" value="./MonkeyLoader Mods" />
-  </packageSources>
-</configuration>

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ Created from mpmxyz's sample repository.
 
 https://github.com/mpmxyz/ResoniteSampleMod
 
-This is a simple Resonite mod which auto converts MP3 files to WAV files on import.
+This is a simple Resonite mod which auto converts MP3 files to OGG files on import.

--- a/ResoniteMP3.csproj
+++ b/ResoniteMP3.csproj
@@ -35,6 +35,5 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FFMpegCore" Version="5.2.0" />
-    <PackageReference Include="NAudio" Version="2.2.1" />
   </ItemGroup>
 </Project>

--- a/ResoniteMP3.csproj
+++ b/ResoniteMP3.csproj
@@ -34,6 +34,7 @@
 	  </Reference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FFMpegCore" Version="5.2.0" />
     <PackageReference Include="NAudio" Version="2.2.1" />
   </ItemGroup>
 </Project>

--- a/ResoniteMP3.csproj
+++ b/ResoniteMP3.csproj
@@ -21,11 +21,20 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Harmony">
-      <HintPath>$(ResonitePath)\rml_libs\0Harmony.dll</HintPath>
+      <HintPath>$(ResonitePath)\rml_libs\0Harmony-Net9.dll</HintPath>
     </Reference>
     <Reference Include="ResoniteModLoader">
       <HintPath>$(ResonitePath)\Libraries\ResoniteModLoader.dll</HintPath>
     </Reference>
+	  <Reference Include="FrooxEngine">
+		  <HintPath>$(ResonitePath)\FrooxEngine.dll</HintPath>
+	  </Reference>
+	  <Reference Include="Elements.Assets">
+		  <HintPath>$(ResonitePath)\Elements.Assets.dll</HintPath>
+	  </Reference>
+	  <Reference Include="Elements.Core">
+		  <HintPath>$(ResonitePath)\Elements.Core.dll</HintPath>
+	  </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Mod.RML/**/*.cs" />

--- a/ResoniteMP3.csproj
+++ b/ResoniteMP3.csproj
@@ -11,9 +11,6 @@
     <PostBuildEvent Condition="$([MSBuild]::IsOSPlatform('Windows'))">
       copy /Y "$(AssemblyName).dll" "$(ResonitePath)\rml_mods\$(AssemblyName).dll"
 	</PostBuildEvent>
-    <PostBuildEvent Condition="$([MSBuild]::IsOSPlatform('Linux'))">
-      cp -f "$(AssemblyName).dll" "$(ResonitePath)/rml_mods/$(AssemblyName).dll"
-	</PostBuildEvent>
     <AssemblyName>ResoniteMPThree</AssemblyName>
     <Authors>__Choco__</Authors>
     <Product />
@@ -35,11 +32,6 @@
 	  <Reference Include="Elements.Core">
 		  <HintPath>$(ResonitePath)\Elements.Core.dll</HintPath>
 	  </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Mod.RML/**/*.cs" />
-    <Compile Include="Patches.Harmony/**/*.cs" />
-    <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NAudio" Version="2.2.1" />

--- a/otherCsproj.csproj
+++ b/otherCsproj.csproj
@@ -8,7 +8,7 @@
     <TargetFramework>net9</TargetFramework>
     <AssemblyTitle>ResoniteMP3</AssemblyTitle>
     <Product>ResoniteMP3</Product>
-    <Description>Converts MP3 files to WAV on import</Description>
+    <Description>Converts MP3 files to OGG on import</Description>
     <Copyright>MIT</Copyright>
     <Version>3.0.0</Version>
     <PackageProjectUrl>$(PROJECT_URL)</PackageProjectUrl>

--- a/otherCsproj.csproj
+++ b/otherCsproj.csproj
@@ -5,12 +5,12 @@
     <VariantSuffix Condition="'$(VariantSuffix)' == ''">Common</VariantSuffix>
     <AssemblyName>ResoniteMP3</AssemblyName>
     <Authors>__Choco__</Authors>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net9</TargetFramework>
     <AssemblyTitle>ResoniteMP3</AssemblyTitle>
     <Product>ResoniteMP3</Product>
     <Description>Converts MP3 files to WAV on import</Description>
     <Copyright>MIT</Copyright>
-    <Version>2.1.0</Version>
+    <Version>3.0.0</Version>
     <PackageProjectUrl>$(PROJECT_URL)</PackageProjectUrl>
     <PackageReleaseNotes>$(RELEASE_NOTES)</PackageReleaseNotes>
     <PackageTags>Resonite</PackageTags>
@@ -38,85 +38,4 @@
   <PropertyGroup>
     <DefaultItemExcludes>$(DefaultItemExcludes);obj/**</DefaultItemExcludes>
   </PropertyGroup>
-  <ItemGroup>
-	  <Compile Remove="bin\**" />
-	  <Compile Remove="Mod.Monkey\**" />
-	  <Compile Remove="Mod.RML\**" />
-	  <Compile Remove="MonkeyLoader GamePacks\**" />
-	  <Compile Remove="MonkeyLoader Mods\**" />
-	  <Compile Remove="Patches.Harmony\**" />
-	  <Compile Remove="TestMonkey\**" />
-	  <Compile Remove="TestRML\**" />
-	  <Compile Remove="Test\**" />
-	  <EmbeddedResource Remove="bin\**" />
-	  <EmbeddedResource Remove="Mod.Monkey\**" />
-	  <EmbeddedResource Remove="Mod.RML\**" />
-	  <EmbeddedResource Remove="MonkeyLoader GamePacks\**" />
-	  <EmbeddedResource Remove="MonkeyLoader Mods\**" />
-	  <EmbeddedResource Remove="Patches.Harmony\**" />
-	  <EmbeddedResource Remove="TestMonkey\**" />
-	  <EmbeddedResource Remove="TestRML\**" />
-	  <EmbeddedResource Remove="Test\**" />
-	  <None Remove="bin\**" />
-	  <None Remove="Mod.Monkey\**" />
-	  <None Remove="Mod.RML\**" />
-	  <None Remove="MonkeyLoader GamePacks\**" />
-	  <None Remove="MonkeyLoader Mods\**" />
-	  <None Remove="Patches.Harmony\**" />
-	  <None Remove="TestMonkey\**" />
-	  <None Remove="TestRML\**" />
-	  <None Remove="Test\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>$(ResonitePath)\Resonite_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Elements.Assets">
-      <HintPath>$(ResonitePath)\Resonite_Data\Managed\Elements.Assets.dll</HintPath>
-    </Reference>
-    <Reference Include="Elements.Core">
-      <HintPath>$(ResonitePath)\Resonite_Data\Managed\Elements.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Elements.Quantity">
-      <HintPath>$(ResonitePath)\Resonite_Data\Managed\Elements.Quantity.dll</HintPath>
-    </Reference>
-    <Reference Include="FrooxEngine">
-      <HintPath>$(ResonitePath)\Resonite_Data\Managed\FrooxEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="FrooxEngine.Commands">
-      <HintPath>$(ResonitePath)\Resonite_Data\Managed\FrooxEngine.Commands.dll</HintPath>
-    </Reference>
-    <Reference Include="FrooxEngine.Weaver">
-      <HintPath>$(ResonitePath)\Resonite_Data\Managed\FrooxEngine.Weaver.dll</HintPath>
-    </Reference>
-    <Reference Include="ProtoFlux.Core">
-      <HintPath>$(ResonitePath)\Resonite_Data\Managed\ProtoFlux.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="ProtoFlux.Nodes.Core">
-      <HintPath>$(ResonitePath)\Resonite_Data\Managed\ProtoFlux.Nodes.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="ProtoFlux.Nodes.FrooxEngine">
-      <HintPath>$(ResonitePath)\Resonite_Data\Managed\ProtoFlux.Nodes.FrooxEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="ProtoFluxBindings">
-      <HintPath>$(ResonitePath)\Resonite_Data\Managed\ProtoFluxBindings.dll</HintPath>
-    </Reference>
-    <Reference Include="QuantityX">
-      <HintPath>$(ResonitePath)\Resonite_Data\Managed\QuantityX.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="obj\**\*AssemblyAttributes.cs" />
-    <Compile Remove="obj\**\*AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Remove="Test" />
-    <Folder Remove="TestRML" />
-    <Folder Remove="TestMonkey" />
-    <Folder Remove="Patches.Harmony" />
-    <Folder Remove="Mod.Monkey" />
-    <Folder Remove="Mod.RML" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
This change fixes #5 and makes OGG the only supported format. This should make networking faster when you are sharing MP3 files.

This PR updates the repository to NET9 in preparation for the performance update, as well as swapping out NAudio for FFMPEG.